### PR TITLE
Fix for Android 5 when there is no internet connection

### DIFF
--- a/Hdhomerun-signal-meter/AndroidManifest.xml
+++ b/Hdhomerun-signal-meter/AndroidManifest.xml
@@ -4,7 +4,8 @@
     <uses-sdk android:minSdkVersion="7" android:targetSdkVersion="18"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"></uses-permission>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission> 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"></uses-permission>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <application android:icon="@drawable/antenna_icon" android:label="@string/app_name">
         <activity android:name="com.zaren.HdhomerunActivity"
                   android:label="@string/app_name" android:screenOrientation="unspecified" android:configChanges="keyboardHidden|orientation">

--- a/Hdhomerun-signal-meter/src/com/zaren/HdhomerunActivity.java
+++ b/Hdhomerun-signal-meter/src/com/zaren/HdhomerunActivity.java
@@ -155,7 +155,7 @@ public class HdhomerunActivity extends Activity
 
 	public void discoverDevices()
 	{
-       Boolean isWifi = wifiIpAddress(context) != null;
+       boolean isWifi = wifiIpAddress(context) != null;
 
        if(isWifi == false)
 	   {


### PR DESCRIPTION
First, thank you for this great tool! And you're extra awesome for putting it on Github :)

This is my first time working on an Android app so forgive me if I've done something wrong.
The situation I encountered was that when I had only my phone, a wifi AP, and the hdhomerun, Android 5 does not consider the Wifi connected without access to the internet and so I couldn't control the hdhomerun. This change should just check for an IP Address on the wifi interface and then proceed with discovering the hdhomerun devices.
